### PR TITLE
Replaces /control with /common for issue 1877 of eventyay

### DIFF
--- a/eventyay_stripe/signals.py
+++ b/eventyay_stripe/signals.py
@@ -156,7 +156,7 @@ def nav_o(sender, request, organizer, **kwargs):
             'url': reverse('plugins:eventyay_stripe:settings.connect', kwargs={
                 'organizer': request.organizer.slug
             }),
-            'parent': reverse('control:organizer.edit', kwargs={
+            'parent': reverse('eventyay_common:organizer.edit', kwargs={
                 'organizer': request.organizer.slug
             }),
             'active': 'settings.connect' in url.url_name,

--- a/eventyay_stripe/urls.py
+++ b/eventyay_stripe/urls.py
@@ -21,7 +21,7 @@ event_patterns = [
 urlpatterns = [
     re_path(r'^control/event/(?P<organizer>[^/]+)/(?P<event>[^/]+)/stripe/disconnect/$', oauth_disconnect,
             name='oauth.disconnect'),
-    re_path(r'^control/organizer/(?P<organizer>[^/]+)/stripeconnect/$', OrganizerSettingsFormView.as_view(),
+    re_path(r'^common/organizer/(?P<organizer>[^/]+)/stripeconnect/$', OrganizerSettingsFormView.as_view(),
             name='settings.connect'),
     re_path(r'^_stripe/webhook/$', webhook, name='webhook'),
     re_path(r'^_stripe/oauth_return/$', oauth_return, name='oauth.return'),


### PR DESCRIPTION
Fixes admin mode `organizer.edit` error in eventyay.

Error Screenshot :
<img width="1465" height="482" alt="Screenshot 2026-01-22 at 9 56 58 PM" src="https://github.com/user-attachments/assets/294aa91a-0618-4817-9a40-54e7ea446ba8" />

Stacktrace :
<img width="1181" height="109" alt="Screenshot 2026-01-22 at 9 59 14 PM" src="https://github.com/user-attachments/assets/f4b1d345-4e06-49ff-8082-85378c891b3c" />

Reference of comment : [LINK](https://github.com/fossasia/eventyay/pull/1961#issuecomment-3785361220)
Reference of issue : [#1877](https://github.com/fossasia/eventyay/issues/1877)
Reference of PR : [#1961](https://github.com/fossasia/eventyay/pull/1961)

## Summary by Sourcery

Update Stripe plugin organizer settings routes to use the shared /common organizer namespace instead of the deprecated /control namespace.

Bug Fixes:
- Fix admin organizer settings navigation by pointing the parent link to the common organizer edit route.
- Align the Stripe organizer settings URL pattern with the common organizer route to prevent organizer.edit errors in admin mode.