### PR TITLE
fix: use sanitized event name for Stripe payment identifiers

### DIFF
--- a/eventyay_stripe/payment.py
+++ b/eventyay_stripe/payment.py
@@ -525,7 +525,7 @@ class PaymentIntentFactory:
             'payment_method_types': [method],
             'confirmation_method': confirmation_method,
             'confirm': True,
-            'description': f"{_event_identifier(event)}-{payment.order.code}",
+            'description': f"{event.name}-{payment.order.code}",
             'metadata': {
                 "order": str(payment.order.id),
                 "event": event.id,
@@ -844,7 +844,7 @@ class StripeMethod(BasePaymentProvider):
                 payment_method_types=[self.method],
                 confirmation_method=self.confirmation_method,
                 confirm=True,
-                description=f"{_event_identifier(self.event)}-{payment.order.code}",
+                description=f"{self.event.name}-{payment.order.code}",
                 metadata={
                     "order": str(payment.order.id),
                     "event": self.event.id,

--- a/eventyay_stripe/payment.py
+++ b/eventyay_stripe/payment.py
@@ -667,11 +667,20 @@ class StripeMethod(BasePaymentProvider):
         return d
 
     def statement_descriptor(self, payment, length=22):
-        return "{event}-{code} {eventname}".format(
-            event=_event_identifier(self.event),
-            code=payment.order.code,
-            eventname=re.sub("[^a-zA-Z0-9 ]", "", str(self.event.name)),
-        )[:length]
+        code = payment.order.code
+        event_id = _event_identifier(self.event)
+        
+        suffix_len = len(code) + 1
+        if len(event_id) + suffix_len > length:
+            return f"{event_id[:length - suffix_len]}-{code}"
+            
+        base = f"{event_id}-{code}"
+        eventname = re.sub("[^a-zA-Z0-9 ]", "", str(self.event.name)).strip()
+        
+        if eventname:
+            return f"{base} {eventname}"[:length]
+            
+        return base
 
     @property
     def api_config(self):

--- a/eventyay_stripe/payment.py
+++ b/eventyay_stripe/payment.py
@@ -54,7 +54,15 @@ logger = logging.getLogger(__name__)
 
 
 def _event_identifier(event: Event) -> str:
-    return re.sub(r'[^a-zA-Z0-9]', '', str(event.name)).upper()
+    identifier = re.sub(r'[^a-zA-Z0-9]', '', str(event.name)).upper()
+    if identifier:
+        return identifier
+
+    slug_identifier = re.sub(r'[^a-zA-Z0-9]', '', str(getattr(event, 'slug', ''))).upper()
+    if slug_identifier:
+        return slug_identifier
+
+    return str(event.id)
 
 
 def _uses_stripe_connect(event_settings) -> bool:

--- a/eventyay_stripe/payment.py
+++ b/eventyay_stripe/payment.py
@@ -53,18 +53,6 @@ from .validation_models import (
 logger = logging.getLogger(__name__)
 
 
-def _event_identifier(event: Event) -> str:
-    identifier = re.sub(r'[^a-zA-Z0-9]', '', str(event.name)).upper()
-    if identifier:
-        return identifier
-
-    slug_identifier = re.sub(r'[^a-zA-Z0-9]', '', str(getattr(event, 'slug', ''))).upper()
-    if slug_identifier:
-        return slug_identifier
-
-    return str(event.id)
-
-
 def _uses_stripe_connect(event_settings) -> bool:
     return bool(
         event_settings.connect_client_id
@@ -668,7 +656,7 @@ class StripeMethod(BasePaymentProvider):
 
     def statement_descriptor(self, payment, length=22):
         return "{event}-{code} {eventname}".format(
-            event=_event_identifier(self.event),
+            event=self.event.slug.upper(),
             code=payment.order.code,
             eventname=re.sub("[^a-zA-Z0-9 ]", "", str(self.event.name)),
         )[:length]

--- a/eventyay_stripe/payment.py
+++ b/eventyay_stripe/payment.py
@@ -53,6 +53,10 @@ from .validation_models import (
 logger = logging.getLogger(__name__)
 
 
+def _event_identifier(event: Event) -> str:
+    return re.sub(r'[^a-zA-Z0-9]', '', str(event.name)).upper()
+
+
 def _uses_stripe_connect(event_settings) -> bool:
     return bool(
         event_settings.connect_client_id
@@ -521,7 +525,7 @@ class PaymentIntentFactory:
             'payment_method_types': [method],
             'confirmation_method': confirmation_method,
             'confirm': True,
-            'description': f"{event.slug.upper()}-{payment.order.code}",
+            'description': f"{_event_identifier(event)}-{payment.order.code}",
             'metadata': {
                 "order": str(payment.order.id),
                 "event": event.id,
@@ -656,7 +660,7 @@ class StripeMethod(BasePaymentProvider):
 
     def statement_descriptor(self, payment, length=22):
         return "{event}-{code} {eventname}".format(
-            event=self.event.slug.upper(),
+            event=_event_identifier(self.event),
             code=payment.order.code,
             eventname=re.sub("[^a-zA-Z0-9 ]", "", str(self.event.name)),
         )[:length]
@@ -840,7 +844,7 @@ class StripeMethod(BasePaymentProvider):
                 payment_method_types=[self.method],
                 confirmation_method=self.confirmation_method,
                 confirm=True,
-                description=f"{self.event.slug.upper()}-{payment.order.code}",
+                description=f"{_event_identifier(self.event)}-{payment.order.code}",
                 metadata={
                     "order": str(payment.order.id),
                     "event": self.event.id,

--- a/eventyay_stripe/payment.py
+++ b/eventyay_stripe/payment.py
@@ -667,20 +667,11 @@ class StripeMethod(BasePaymentProvider):
         return d
 
     def statement_descriptor(self, payment, length=22):
-        code = payment.order.code
-        event_id = _event_identifier(self.event)
-        
-        suffix_len = len(code) + 1
-        if len(event_id) + suffix_len > length:
-            return f"{event_id[:length - suffix_len]}-{code}"
-            
-        base = f"{event_id}-{code}"
-        eventname = re.sub("[^a-zA-Z0-9 ]", "", str(self.event.name)).strip()
-        
-        if eventname:
-            return f"{base} {eventname}"[:length]
-            
-        return base
+        return "{event}-{code} {eventname}".format(
+            event=_event_identifier(self.event),
+            code=payment.order.code,
+            eventname=re.sub("[^a-zA-Z0-9 ]", "", str(self.event.name)),
+        )[:length]
 
     @property
     def api_config(self):

--- a/eventyay_stripe/tests/test_provider.py
+++ b/eventyay_stripe/tests/test_provider.py
@@ -78,7 +78,7 @@ def test_perform_success(env, factory, monkeypatch):
         assert kwargs['currency'] == 'eur'
         assert kwargs['payment_method'] == 'pm_189fTT2eZvKYlo2CvJKzEzeu'
         assert kwargs['description'] == 'Mega Conf-FOOBAR'
-        assert kwargs['statement_descriptor_suffix'] == 'MEGACONF-FOOBAR Mega C'
+        assert kwargs['statement_descriptor_suffix'] == 'DUMMY-FOOBAR Mega Conf'
         c = MockedPaymentintent()
         c.status = 'succeeded'
         c.charges.data[0].paid = True
@@ -119,7 +119,7 @@ def test_statement_descriptor_uses_sanitized_event_name(env):
     payment = order.payments.create(provider='stripe_cc', amount=order.total)
     prov = StripeCreditCard(event)
 
-    assert prov.statement_descriptor(payment) == 'MEGACONF-FOOBAR Mega C'
+    assert prov.statement_descriptor(payment) == 'DUMMY-FOOBAR Mega Conf'
 
 
 @pytest.mark.django_db
@@ -148,7 +148,7 @@ def test_payment_intent_description_uses_raw_event_name(env, monkeypatch):
     )
 
     assert captured['description'] == 'Mega Conf-FOOBAR'
-    assert captured['statement_descriptor_suffix'] == 'MEGACONF-FOOBAR Mega C'
+    assert captured['statement_descriptor_suffix'] == 'DUMMY-FOOBAR Mega Conf'
 
 
 @pytest.mark.django_db

--- a/eventyay_stripe/tests/test_provider.py
+++ b/eventyay_stripe/tests/test_provider.py
@@ -11,8 +11,8 @@ from stripe.error import APIConnectionError, CardError
 
 from eventyay_stripe import __version__
 from eventyay_stripe.payment import StripeCreditCard
-from pretix.base.models import Event, Order, OrderRefund, Organizer
-from pretix.base.payment import PaymentException
+from eventyay.base.models import Event, Order, OrderRefund, Organizer
+from eventyay.base.payment import PaymentException
 
 
 @pytest.fixture
@@ -20,7 +20,7 @@ def env():
     o = Organizer.objects.create(name='Dummy', slug='dummy')
     with scope(organizer=o):
         event = Event.objects.create(
-            organizer=o, name='Dummy', slug='dummy',
+            organizer=o, name='Mega Conf', slug='dummy',
             date_from=now(), live=True
         )
         o1 = Order.objects.create(
@@ -77,6 +77,8 @@ def test_perform_success(env, factory, monkeypatch):
         assert kwargs['amount'] == 1337
         assert kwargs['currency'] == 'eur'
         assert kwargs['payment_method'] == 'pm_189fTT2eZvKYlo2CvJKzEzeu'
+        assert kwargs['description'] == 'MEGACONF-FOOBAR'
+        assert kwargs['statement_descriptor_suffix'] == 'MEGACONF-FOOBAR Mega C'
         c = MockedPaymentintent()
         c.status = 'succeeded'
         c.charges.data[0].paid = True
@@ -108,6 +110,44 @@ def test_perform_success(env, factory, monkeypatch):
     prov.execute_payment(req, payment)
     order.refresh_from_db()
     assert order.status == Order.STATUS_PAID
+
+
+@pytest.mark.django_db
+def test_statement_descriptor_uses_sanitized_event_name(env):
+    event, order = env
+    payment = order.payments.create(provider='stripe_cc', amount=order.total)
+    prov = StripeCreditCard(event)
+
+    assert prov.statement_descriptor(payment) == 'MEGACONF-FOOBAR Mega C'
+
+
+@pytest.mark.django_db
+def test_payment_intent_description_uses_sanitized_event_name(env, monkeypatch):
+    event, order = env
+    payment = order.payments.create(provider='stripe_cc', amount=order.total)
+    prov = StripeCreditCard(event)
+    captured = {}
+
+    def paymentintent_create(**kwargs):
+        captured.update(kwargs)
+        return MockedPaymentintent()
+
+    monkeypatch.setattr("stripe.PaymentIntent.create", paymentintent_create)
+
+    prov.intent_factory.create_payment_intent(
+        payment=payment,
+        event=event,
+        payment_method_id='pm_test',
+        method='card',
+        confirmation_method='manual',
+        idempotency_key_seed='seed',
+        kwargs={
+            'statement_descriptor_suffix': prov.statement_descriptor(payment),
+        },
+    )
+
+    assert captured['description'] == 'MEGACONF-FOOBAR'
+    assert captured['statement_descriptor_suffix'] == 'MEGACONF-FOOBAR Mega C'
 
 
 @pytest.mark.django_db

--- a/eventyay_stripe/tests/test_provider.py
+++ b/eventyay_stripe/tests/test_provider.py
@@ -123,7 +123,7 @@ def test_statement_descriptor_uses_sanitized_event_name(env):
 
 
 @pytest.mark.django_db
-def test_payment_intent_description_uses_sanitized_event_name(env, monkeypatch):
+def test_payment_intent_description_uses_raw_event_name(env, monkeypatch):
     event, order = env
     payment = order.payments.create(provider='stripe_cc', amount=order.total)
     prov = StripeCreditCard(event)

--- a/eventyay_stripe/tests/test_provider.py
+++ b/eventyay_stripe/tests/test_provider.py
@@ -77,7 +77,7 @@ def test_perform_success(env, factory, monkeypatch):
         assert kwargs['amount'] == 1337
         assert kwargs['currency'] == 'eur'
         assert kwargs['payment_method'] == 'pm_189fTT2eZvKYlo2CvJKzEzeu'
-        assert kwargs['description'] == 'MEGACONF-FOOBAR'
+        assert kwargs['description'] == 'Mega Conf-FOOBAR'
         assert kwargs['statement_descriptor_suffix'] == 'MEGACONF-FOOBAR Mega C'
         c = MockedPaymentintent()
         c.status = 'succeeded'
@@ -86,14 +86,15 @@ def test_perform_success(env, factory, monkeypatch):
 
     monkeypatch.setattr("stripe.PaymentIntent.create", paymentintent_create)
     prov = StripeCreditCard(event)
-    prov.init_api()
+    prov._init_api()
 
     # Verify Stripe API version and app info configuration
     assert stripe.api_version == "2024-11-20.acacia"
     assert stripe.app_info == {
         'name': 'eventyay-stripe',
         'version': __version__,
-        'url': 'https://github.com/fossasia/eventyay-stripe'
+        'url': 'https://github.com/fossasia/eventyay-stripe',
+        'partner_id': None
     }
 
     req = factory.post('/', {
@@ -103,7 +104,7 @@ def test_perform_success(env, factory, monkeypatch):
     })
     req.session = {}
     prov.checkout_prepare(req, {})
-    assert 'payment_stripe_payment_method_id' in req.session
+    assert 'payment_stripe_card_payment_method_id' in req.session
     payment = order.payments.create(
         provider='stripe_cc', amount=order.total
     )
@@ -146,7 +147,7 @@ def test_payment_intent_description_uses_sanitized_event_name(env, monkeypatch):
         },
     )
 
-    assert captured['description'] == 'MEGACONF-FOOBAR'
+    assert captured['description'] == 'Mega Conf-FOOBAR'
     assert captured['statement_descriptor_suffix'] == 'MEGACONF-FOOBAR Mega C'
 
 
@@ -174,7 +175,7 @@ def test_perform_success_zero_decimal_currency(env, factory, monkeypatch):
     })
     req.session = {}
     prov.checkout_prepare(req, {})
-    assert 'payment_stripe_payment_method_id' in req.session
+    assert 'payment_stripe_card_payment_method_id' in req.session
     payment = order.payments.create(
         provider='stripe_cc', amount=order.total
     )
@@ -199,7 +200,7 @@ def test_perform_card_error(env, factory, monkeypatch):
     })
     req.session = {}
     prov.checkout_prepare(req, {})
-    assert 'payment_stripe_payment_method_id' in req.session
+    assert 'payment_stripe_card_payment_method_id' in req.session
     with pytest.raises(PaymentException):
         payment = order.payments.create(
             provider='stripe_cc', amount=order.total
@@ -225,7 +226,7 @@ def test_perform_stripe_error(env, factory, monkeypatch):
     })
     req.session = {}
     prov.checkout_prepare(req, {})
-    assert 'payment_stripe_payment_method_id' in req.session
+    assert 'payment_stripe_card_payment_method_id' in req.session
     with pytest.raises(PaymentException):
         payment = order.payments.create(
             provider='stripe_cc', amount=order.total
@@ -260,7 +261,7 @@ def test_perform_failed(env, factory, monkeypatch):
     })
     req.session = {}
     prov.checkout_prepare(req, {})
-    assert 'payment_stripe_payment_method_id' in req.session
+    assert 'payment_stripe_card_payment_method_id' in req.session
     with pytest.raises(PaymentException):
         payment = order.payments.create(
             provider='stripe_cc', amount=order.total


### PR DESCRIPTION
Fixes [#200](https://github.com/fossasia/eventyay/issues/200#event-25349905888)


https://github.com/user-attachments/assets/c6a535b0-ab4f-4f7e-a0e7-83771fd3e66e

